### PR TITLE
Make KnxClientSend

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,15 +50,15 @@ According to the KNX specification the communication is defaulted to _tunneling_
 Network Address Translation (NAT). The knx-core also offers the communication using _routing_
 instead of tunneling.
 
-#### Tunneling without NAT (default)
+#### Tunneling without NAT (default, recommended)
 
 ```
 DefaultKnxClient.createStarted();                   // IP Address resolved using discovery service
-DefaultKnxClient.createStarted("192.168.0.3");      // Defined IP Address with default KNX Port (3671)
+DefaultKnxClient.createStarted("192.168.0.3");      // Defined IP Address with default KNX Port
 DefaultKnxClient.createStarted("192.168.0.3:1234"); // Defined IP Address with custom KNX Port
 ```
 
-Using `ConfigBuilder` we can configure the KNX Client with same settings like above:
+Using `ConfigBuilder` we can configure the KNX Client like above:
 
 ```
 var config = ConfigBuilder.tunneling().build();     
@@ -71,8 +71,8 @@ DefaultKnxClient.createStarted(config);
 #### Tunneling with NAT
 
 Network Address Translation (NAT) is available for _tunneling_ mode only; for _routing_
-NAT is not required. Sometimes we need NAT, one example would be in dockerized image.
-To use the NAT we need to enable it explicitly by `true`:
+NAT is not required. Sometimes we need NAT, eg. in dockerized image. To use the NAT we 
+need to enable it explicitly by `true`:
 
 ```
 var config = ConfigBuilder.tunneling(true).build(); 
@@ -89,11 +89,11 @@ If you specific an IP Address that is in a Class D address (i.e. four first bits
 communication will be used automatically. The standardized IP multicast address for KNX is `224.0.23.12`.
 
 ```
-DefaultKnxClient.createStarted("224.0.23.12");       // IP Multicast Address (KNX Specification)
-DefaultKnxClient.createStarted("224.1.2.3");         // IP Multicast Address (Custom)
+DefaultKnxClient.createStarted("224.0.23.12"); // IP Multicast Address (KNX Specification)
+DefaultKnxClient.createStarted("224.1.2.3");   // IP Multicast Address (Custom)
 ```
 
-You can also use the `ConfigBuilder` to define the communication mode:
+You can use the `ConfigBuilder` to define the _routing_ mode:
 
 ```
 var config = ConfigBuilder.routing().build();     
@@ -284,7 +284,6 @@ public final class LampInverseExample {
             // send a 'read' request to KNX
             client.readRequest(readGroupAddress);
 
-            // wait a bit (usually few milliseconds, but up to 1 second maximum)
             // KNX actuator will send a response to the KNX client with actual lamp status
             final var status = client.getStatusPool().getValue(readGroupAddress, DPT1.SWITCH).getValue();
 

--- a/knx-examples/src/main/java/li/pitschmann/knx/examples/lamp_toggle/LampToggleExample.java
+++ b/knx-examples/src/main/java/li/pitschmann/knx/examples/lamp_toggle/LampToggleExample.java
@@ -53,7 +53,6 @@ public final class LampToggleExample {
             // send a 'read' request to KNX
             client.readRequest(readGroupAddress);
 
-            // wait a bit (usually few milliseconds, but up to 1 second maximum)
             // KNX actuator will send a response to the KNX client with actual lamp status
             final var lampStatus = client.getStatusPool().getValue(readGroupAddress, DPT1.SWITCH).getValue();
 

--- a/src/main/java/li/pitschmann/knx/core/communication/InternalKnxClient.java
+++ b/src/main/java/li/pitschmann/knx/core/communication/InternalKnxClient.java
@@ -101,7 +101,7 @@ public final class InternalKnxClient implements AutoCloseable {
         this.pluginManager = new PluginManager(config);
 
         // In case of forced shutdown (e.g. CTRL+C) we should try to close the client properly
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> close()));
+        Runtime.getRuntime().addShutdownHook(new Thread(this::close));
     }
 
     /**

--- a/src/main/java/li/pitschmann/knx/core/communication/KnxClient.java
+++ b/src/main/java/li/pitschmann/knx/core/communication/KnxClient.java
@@ -105,29 +105,19 @@ public interface KnxClient extends AutoCloseable {
     <T extends ResponseBody> CompletableFuture<T> send(final RequestBody requestBody, final long msTimeout);
 
     /**
-     * Sends a WRITE request to {@link GroupAddress} with value of {@link DataPointValue}
-     * <p>
-     * For tunneling, this method is a blocking-operation, due awaiting for acknowledge packet.
-     * If you want to use a non-blocking operation, use {@link #send(Body)} or {@link #send(RequestBody, long)}
-     * instead.
-     * </p>
+     * Sends a WRITE request to {@link GroupAddress} with value of {@link DataPointValue} asynchronously.
      *
      * @param address        the recipient which is an KNX group address
      * @param dataPointValue value to be sent to KNX group address
-     * @return {@code true} if the write request was successful, otherwise {@code false}
+     * @return a {@link CompletableFuture}, if the write request was successful it will contain a {@code true}, otherwise {@code false}
      */
-    boolean writeRequest(final GroupAddress address, final DataPointValue dataPointValue);
+    CompletableFuture<Boolean> writeRequest(final GroupAddress address, final DataPointValue dataPointValue);
 
     /**
-     * Sends a READ request to {@link GroupAddress}
-     * <p>
-     * For tunneling, this method is a blocking-operation, due awaiting for acknowledge packet.
-     * If you want to use a non-blocking operation, use {@link #send(Body)} or {@link #send(RequestBody, long)}
-     * instead.
-     * </p>
+     * Sends a READ request to {@link GroupAddress} asynchronously.
      *
      * @param address this is the KNX group address we want to send the read request to obtain the current value
-     * @return {@code true} if the write request was successful, otherwise {@code false}
+     * @return a {@link CompletableFuture}, if the read request was successful it will contain a {@code true}, otherwise {@code false}
      */
-    boolean readRequest(final GroupAddress address);
+    CompletableFuture<Boolean> readRequest(final GroupAddress address);
 }

--- a/src/test/java/li/pitschmann/knx/core/communication/DefaultKnxClientTest.java
+++ b/src/test/java/li/pitschmann/knx/core/communication/DefaultKnxClientTest.java
@@ -237,8 +237,11 @@ public class DefaultKnxClientTest {
     @DisplayName("Success: Test KNX client instantiation using routing service (via multicast)")
     public void testRouting(final MockServer mockServer) {
         try (final var client = mockServer.createTestClient()) {
-            client.readRequest(GroupAddress.of(11, 4, 67));
-            client.writeRequest(GroupAddress.of(11, 4, 67), DPT1.SWITCH.of(true));
+            // for routing, read and write should be immediately completed with 'true'
+            assertThat(client.readRequest(GroupAddress.of(11, 4, 67)))
+                    .isCompletedWithValue(true);
+            assertThat(client.writeRequest(GroupAddress.of(11, 4, 67), DPT1.SWITCH.of(true)))
+                    .isCompletedWithValue(true);
             mockServer.waitForReceivedServiceType(ServiceType.ROUTING_INDICATION, 2);
         } catch (final Throwable t) {
             fail("Unexpected test state", t);

--- a/src/test/java/li/pitschmann/knx/core/test/MockServer.java
+++ b/src/test/java/li/pitschmann/knx/core/test/MockServer.java
@@ -393,7 +393,7 @@ public final class MockServer implements Runnable, Closeable {
      * @return string of received bodies, comma-separated
      */
     public String getReceivedBodiesAsString() {
-        return this.receivedBodies.stream().map(b -> b.getClass().getSimpleName()).collect(Collectors.joining(System.lineSeparator()));
+        return new ArrayList<>(this.receivedBodies).stream().map(b -> b.getClass().getSimpleName()).collect(Collectors.joining(System.lineSeparator()));
     }
 
     /**
@@ -411,7 +411,7 @@ public final class MockServer implements Runnable, Closeable {
      * @return string of sent bodies, comma-separated
      */
     public String getSentBodiesAsString() {
-        return this.sentBodies.stream().map(b -> b.getClass().getSimpleName()).collect(Collectors.joining(System.lineSeparator()));
+        return new ArrayList<>(this.sentBodies).stream().map(b -> b.getClass().getSimpleName()).collect(Collectors.joining(System.lineSeparator()));
     }
 
     /**

--- a/src/test/java/li/pitschmann/knx/core/test/MockServerCommandParser.java
+++ b/src/test/java/li/pitschmann/knx/core/test/MockServerCommandParser.java
@@ -68,11 +68,11 @@ public class MockServerCommandParser {
             final var requestBody = new DefaultTunnelingStrategy().createRequest(this.mockServer, CEMI.of(Bytes.toByteArray("2900bce010c84c0f0300800c23")));
             return Collections.singletonList(new RequestMockAction(this.mockServer, requestBody));
         }
-        // 100-times tunnelling request with CEMI bytes
+        // 1000-times tunnelling request with CEMI bytes
         // (used in PerformanceKnxTest)
-        else if ("cemi(260)={2E00BCE010FF0A96010081}".equals(command)) {
-            final var actions = new ArrayList<MockAction>(260);
-            for (int i = 0; i < 260; i++) {
+        else if ("cemi(1000)={2E00BCE010FF0A96010081}".equals(command)) {
+            final var actions = new ArrayList<MockAction>(1000);
+            for (int i = 0; i < 1000; i++) {
                 final var requestBody = new DefaultTunnelingStrategy().createRequest(this.mockServer, CEMI.of(Bytes.toByteArray("2E00BCE010FF0A96010081")));
                 actions.add(new RequestMockAction(this.mockServer, requestBody));
             }

--- a/src/test/java/li/pitschmann/knx/core/test/MockServerDatagramChannel.java
+++ b/src/test/java/li/pitschmann/knx/core/test/MockServerDatagramChannel.java
@@ -30,6 +30,7 @@ import li.pitschmann.knx.core.test.body.MockResponseBody;
 import li.pitschmann.knx.core.utils.Bytes;
 import li.pitschmann.knx.core.utils.Closeables;
 import li.pitschmann.knx.core.utils.Networker;
+import li.pitschmann.knx.core.utils.Sleeper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -144,6 +145,7 @@ public final class MockServerDatagramChannel implements MockServerChannel<Datagr
         }
 
         this.channel.send(byteBuffer, address);
+        Sleeper.milliseconds(1); // add give some time to breathe (KnxPerformanceTest)!
     }
 
     @Override


### PR DESCRIPTION
Both methods are now async per default:
* KnxClient#writeRequest(GroupAddress, DataPointValue)
* KnxClient#readRequest(GroupAddress)

To use a blocking-operation just append the method with `.get()` or `.get(long,TimeUnit)`